### PR TITLE
Fix issue that fileSize is nil on iOS

### DIFF
--- a/Sources/OLEKit/OLEFile.swift
+++ b/Sources/OLEKit/OLEFile.swift
@@ -33,17 +33,13 @@ public final class OLEFile {
     guard FileManager.default.fileExists(atPath: path)
     else { throw OLEError.fileDoesNotExist(path) }
 
-    let attributes = try FileManager.default.attributesOfItem(atPath: path)
-    // swiftlint:disable:next force_cast
-    let fileSize = attributes[FileAttributeKey.size] as! Int
-
     guard let fileHandle = FileHandle(forReadingAtPath: path)
     else { throw OLEError.fileNotAvailableForReading(path: path) }
 
     let allData = fileHandle.readDataToEndOfFile()
     fileHandle.seek(toFileOffset: UInt64(0))
 
-    try self.init(data: allData, fileSize: fileSize, path: path)
+    try self.init(data: allData, path: path)
   }
 
   #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
@@ -51,17 +47,16 @@ public final class OLEFile {
   public convenience init(_ fileWrapper: FileWrapper) throws {
     let fileName = fileWrapper.filename ?? ""
 
-    guard
-      let data = fileWrapper.regularFileContents,
-      let fileSize = fileWrapper.fileAttributes[FileAttributeKey.size.rawValue] as? Int
+    guard let data = fileWrapper.regularFileContents
     else { throw OLEError.fileDoesNotExist(fileName) }
 
-    try self.init(data: data, fileSize: fileSize, path: fileName)
+    try self.init(data: data, path: fileName)
   }
 
   #endif
 
-  private init(data: Data, fileSize: Int, path: String) throws {
+  private init(data: Data, path: String) throws {
+    let fileSize = data.count
     guard fileSize >= 512
     else { throw OLEError.incompleteHeader }
 


### PR DESCRIPTION
Hello!

There was a potential problem with initiating OLEFile.
There is no fileSize attribute, unlike macOS and Linux.

So, I changed to calculate data.count.

I wish 0.3.1 hotfix publish with this PR. (So I set the milestone.)
Thanks.